### PR TITLE
use full path to ts-node executable

### DIFF
--- a/scripts/catalog/fetch.sh
+++ b/scripts/catalog/fetch.sh
@@ -2,4 +2,4 @@
 set -e
 echo "Fetching the catalog"
 
-NODE_OPTIONS="-r dotenv/config -r cross-fetch/polyfill" ts-node ./scripts/catalog/fetch-contentful.ts
+NODE_OPTIONS="-r dotenv/config -r cross-fetch/polyfill" $BUILD_CONTENTS_DIRECTORY/node_modules/.bin/ts-node ./scripts/catalog/fetch-contentful.ts


### PR DESCRIPTION
Was getting the following error:
```
/buildcontents/scripts/catalog/fetch.sh: line 5: ts-node: command not found
```

I'm sure there are other solutions (such as `npm -g ts-node` or using npm scripts to run this command).  This solution is sufficient for now.