### PR TITLE
Revert changes to only pass first 10 pages on home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,19 +8,27 @@ import Home from "@scenes/Home"
 
 interface HomeProps {
   pages: Page[]
+  showing: number
+  total: number
 }
 
-const HomePage: FC<HomeProps> = ({ pages }) => {
-  return <Home pages={pages} />
+const HomePage: FC<HomeProps> = ({ pages, showing, total }) => {
+  return <Home pages={pages} showing={showing} total={total} />
 }
 
 export default HomePage
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   const pages = await getAllPages()
+  const toShow = pages.slice(0, 12)
+
+  const showing = toShow.length
+  const total = pages.length
   return {
     props: {
-      pages,
+      showing,
+      total,
+      pages: toShow,
     },
   }
 }

--- a/src/scenes/Home/Home.tsx
+++ b/src/scenes/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react"
+import { FC } from "react"
 import type { Page } from "@shared/interfaces"
 
 import Head from "next/head"
@@ -8,25 +8,13 @@ import PageCard from "./components/PageCard"
 import styles from "./Home.module.css"
 import FeaturedPageCard from "./components/FeaturedPageCard/FeaturedPageCard"
 
-const NUM_OF_PAGES_TO_SHOW = 10
-const Home: FC<{ pages: Page[] }> = ({ pages }) => {
-  const [lastPageShown, setLastPageShown] = useState(
-    pages.length > NUM_OF_PAGES_TO_SHOW ? NUM_OF_PAGES_TO_SHOW : pages.length,
-  )
-
-  const totalNumberOfPages = pages.length
+const Home: FC<{ pages: Page[]; showing: number; total: number }> = ({
+  pages,
+  showing,
+  total,
+}) => {
   const featuredPage = pages.length > 0 ? pages[0] : null
-  const otherPages = pages.length > 1 ? pages.slice(1, lastPageShown) : []
-
-  const showMorePages = () => {
-    const numOfRemainingPages = pages.length - lastPageShown
-    const numOfExtraPagesToShow =
-      numOfRemainingPages > NUM_OF_PAGES_TO_SHOW
-        ? NUM_OF_PAGES_TO_SHOW
-        : numOfRemainingPages
-    if (numOfExtraPagesToShow > 0)
-      setLastPageShown((lastPageShown) => lastPageShown + numOfExtraPagesToShow)
-  }
+  const otherPages = pages.length > 1 ? pages.slice(1, showing) : []
 
   return (
     <div className={styles.container}>
@@ -43,8 +31,7 @@ const Home: FC<{ pages: Page[] }> = ({ pages }) => {
       </div>
       <button
         className={styles.banner}
-        onClick={showMorePages}
-      >{`Showing ${lastPageShown} of ${totalNumberOfPages}`}</button>
+      >{`Showing ${showing} of ${total}`}</button>
     </div>
   )
 }


### PR DESCRIPTION
Pagination was being done on the client which meant all pages were passed as a prop to the `Home` component.

**Changes**
Revert a previous change to only pass the first 10 pages.
In another PR, we should support per page pagination using graphql
